### PR TITLE
chore: promote project-6 to version 0.0.1 in Staging environment

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -19,6 +19,8 @@ repositories:
   url: https://charts.helm.sh/stable
 - name: banzaicloud-stable
   url: https://kubernetes-charts.banzaicloud.com
+- name: dev
+  url: http://chartmuseum-jx.jenkinsxhackathon.co.uk/
 releases:
 - chart: jenkins-x/jxboot-helmfile-resources
   version: 1.0.16
@@ -96,5 +98,9 @@ releases:
   namespace: jx
   values:
   - versionStream/charts/jx3/jx-build-controller/values.yaml.gotmpl
+- chart: dev/project-6
+  version: 0.0.1
+  name: project-6
+  namespace: jx-staging
 templates: {}
 missingFileHandler: ""


### PR DESCRIPTION
chore: promote project-6 to version 0.0.1 in Staging environment

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge